### PR TITLE
Fix duplicate XP awards and inconsistent reason values in XP history tracking (#385)

### DIFF
--- a/app/models/session.py
+++ b/app/models/session.py
@@ -61,6 +61,8 @@ class Session:
             result['xp_awarded'] = self._xp_awarded
         if hasattr(self, '_xp_calculation'):
             result['xp_calculation'] = self._xp_calculation
+        if hasattr(self, '_new_total_xp'):
+            result['new_total_xp'] = self._new_total_xp
             
         return result
 
@@ -137,10 +139,14 @@ class Session:
                         )
                         # Store XP info for reference
                         updated_session._xp_awarded = xp_result['xp_awarded']
+                        updated_session._xp_calculation = xp_result.get('calculation_details', {})
+                        updated_session._new_total_xp = xp_result.get('new_total', 0)
                     except Exception as xp_error:
                         # Log XP error but don't fail the session end
                         print(f"Warning: Failed to award XP for session: {xp_error}")
                         updated_session._xp_awarded = 0
+                        updated_session._xp_calculation = {}
+                        updated_session._new_total_xp = 0
                 
                 return updated_session
             raise DatabaseError("No data returned from session update")

--- a/app/routes/levels.py
+++ b/app/routes/levels.py
@@ -561,6 +561,7 @@ def end_session():
             'time_spent': session.time_spent,
             'xp_awarded': session.get_xp_awarded(),
             'xp_calculation': session.get_xp_calculation_details(),
+            'new_total_xp': getattr(session, '_new_total_xp', None),
             'message': 'Session completed successfully'
         })
         

--- a/app/static/js/utils/game-progress-manager.js
+++ b/app/static/js/utils/game-progress-manager.js
@@ -119,7 +119,7 @@ class GameProgressManager {
                 this.currentLevel.difficulty
             );
             
-            // End session
+            // End session (this will automatically award XP via backend with 'session_completion' reason)
             const sessionResult = await this.sessionManager.endSession(score, {
                 level_id: this.currentLevel.id,
                 difficulty: this.currentLevel.difficulty,
@@ -127,25 +127,13 @@ class GameProgressManager {
                 ...additionalData
             });
             
-            // Award XP
-            let xpResult = null;
-            try {
-                xpResult = await this.xpCalculator.awardXP(
-                    this.currentLevel.id,
-                    score,
-                    timeSpent,
-                    this.currentLevel.difficulty,
-                    this.currentLevel.sessionId,
-                    'level_completion'
-                );
-            } catch (xpError) {
-                console.warn('[GameProgressManager] XP awarding failed, using preview data:', xpError);
-                xpResult = {
-                    xp_awarded: xpPreview.xp_earned,
-                    calculation_details: xpPreview,
-                    error: xpError.message
-                };
-            }
+            // Extract XP result from session end response
+            // Session.end_session() already awards XP, so we don't need to call awardXP() again
+            const xpResult = {
+                xp_awarded: sessionResult.xp_awarded || 0,
+                calculation_details: sessionResult.xp_calculation || xpPreview,
+                new_total: sessionResult.new_total_xp
+            };
             
             // Mark level as completed
             localStorage.setItem(`cyberquest_level_${this.currentLevel.id}_completed`, 'true');
@@ -215,32 +203,16 @@ class GameProgressManager {
             
             console.log(`[GameProgressManager] Completing session: ${sessionName}, Score: ${score}, Time: ${timeSpent}s`);
             
-            // End session
+            // End session (this will automatically award XP via backend with 'session_completion' reason)
             const sessionResult = await this.sessionManager.endSession(score, additionalData);
             
-            // Award session XP
-            let xpResult = null;
-            try {
-                xpResult = await this.xpCalculator.awardSessionXP(
-                    sessionName,
-                    score,
-                    timeSpent,
-                    null, // no level_id for non-level sessions
-                    sessionId,
-                    'session_completion'
-                );
-            } catch (xpError) {
-                console.warn('[GameProgressManager] Session XP awarding failed:', xpError);
-                // Use basic XP calculation for non-level sessions
-                const baseXP = 50;
-                const scoreMultiplier = score ? Math.max(0.8, score / 100) : 1.0;
-                const estimatedXP = Math.floor(baseXP * scoreMultiplier);
-                
-                xpResult = {
-                    xp_awarded: estimatedXP,
-                    error: xpError.message
-                };
-            }
+            // Extract XP result from session end response
+            // Session.end_session() already awards XP, so we don't need to call awardSessionXP() again
+            const xpResult = {
+                xp_awarded: sessionResult.xp_awarded || 0,
+                calculation_details: sessionResult.xp_calculation || {},
+                new_total: sessionResult.new_total_xp
+            };
             
             this.startTime = null;
             


### PR DESCRIPTION


* Initial plan

* Remove duplicate XP awarding in level completion



* Fix duplicate XP for non-level sessions (Blue Team mode)



* Document XP tracking consistency and single award policy



---------